### PR TITLE
fix the checkstyle bug in bin/ycsb

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,8 @@ A default log4j configuration file is provided in
 
 Because `pegasus/conf` is added into classpath by default, so these configuration files will be 
 found automatically.  Also You can specify configuration file on the command line via `-p`, e.g.:
-
+    
+    # example for specifying. If you have executed this command, skip the "Load the data" phase in section 5.
     ./bin/ycsb load pegasus -s -P workloads/workload_pegasus \
         -p "pegasus.config=file://./pegasus/conf/pegasus.properties" > outputLoad.txt
 

--- a/bin/ycsb
+++ b/bin/ycsb
@@ -193,10 +193,10 @@ def is_distribution():
 # Given module is full module name eg. 'core' or 'couchbase-binding'
 def get_classpath_from_maven(module):
     try:
-        debug("Running 'mvn -pl com.yahoo.ycsb:" + module + " -am package -DskipTests "
+        debug("Running 'mvn -pl com.yahoo.ycsb:" + module + " -am package -DskipTests -Dcheckstyle.skip=true"
               "dependency:build-classpath -DincludeScope=compile -Dmdep.outputFilterFile=true'")
         mvn_output = check_output(["mvn", "-pl", "com.yahoo.ycsb:" + module,
-                                   "-am", "package", "-DskipTests",
+                                   "-am", "package", "-DskipTests","-Dcheckstyle.skip=true",
                                    "dependency:build-classpath",
                                    "-DincludeScope=compile",
                                    "-Dmdep.outputFilterFile=true"])


### PR DESCRIPTION
In func get_classpath_from_maven(), check_output will report checkstyle failed. Skip it.