### PR TITLE
add pegasus multi/batch set/get test api 

### DIFF
--- a/core/src/main/java/com/yahoo/ycsb/measurements/OneMeasurementHdrHistogram.java
+++ b/core/src/main/java/com/yahoo/ycsb/measurements/OneMeasurementHdrHistogram.java
@@ -58,7 +58,7 @@ public class OneMeasurementHdrHistogram extends OneMeasurement {
    */
   public static final String PERCENTILES_PROPERTY_DEFAULT = "95,99";
 
-  List<Integer> percentiles;
+  List<Double> percentiles;
 
   public OneMeasurementHdrHistogram(String name, Properties props) {
     super(name);
@@ -114,7 +114,7 @@ public class OneMeasurementHdrHistogram extends OneMeasurement {
     exporter.write(getName(), "MinLatency(us)", totalHistogram.getMinValue());
     exporter.write(getName(), "MaxLatency(us)", totalHistogram.getMaxValue());
 
-    for (Integer percentile: percentiles) {
+    for (Double percentile: percentiles) {
       exporter.write(getName(), ordinal(percentile) + "PercentileLatency(us)", totalHistogram.getValueAtPercentile(percentile));
     }
     
@@ -162,12 +162,12 @@ public class OneMeasurementHdrHistogram extends OneMeasurement {
      * @param percentileString - comma delimited string of Integer values
      * @return An Integer List of percentile values
      */
-    private List<Integer> getPercentileValues(String percentileString) {
-      List<Integer> percentileValues = new ArrayList<Integer>();
+    private List<Double> getPercentileValues(String percentileString) {
+      List<Double> percentileValues = new ArrayList<Double>();
 
       try {
         for (String rawPercentile: percentileString.split(",")) {
-          percentileValues.add(Integer.parseInt(rawPercentile));
+          percentileValues.add(Double.parseDouble(rawPercentile));
         }
       } catch(Exception e) {
         // If the given hdrhistogram.percentiles value is unreadable for whatever reason,
@@ -186,15 +186,15 @@ public class OneMeasurementHdrHistogram extends OneMeasurement {
      * @param i
      * @return ordinal string
      */
-    private String ordinal(int i) {
+    private String ordinal(Double i) {
       String[] suffixes = new String[] { "th", "st", "nd", "rd", "th", "th", "th", "th", "th", "th" };
-      switch (i % 100) {
+      switch (i.intValue() % 100) {
         case 11:
         case 12:
         case 13:
           return i + "th";
         default:
-          return i + suffixes[i % 10];
+          return i + suffixes[i.intValue() % 10];
       }
     }
 }

--- a/pegasus/pom.xml
+++ b/pegasus/pom.xml
@@ -48,7 +48,7 @@ LICENSE file.
     <dependency>
       <groupId>com.xiaomi.infra</groupId>
       <artifactId>pegasus-client</artifactId>
-      <version>1.10.0-thrift-0.11.0-inlined</version>
+      <version>1.12.SNAPSHOT-thrift-0.11.0-inlined</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>

--- a/pegasus/pom.xml
+++ b/pegasus/pom.xml
@@ -50,6 +50,11 @@ LICENSE file.
       <artifactId>pegasus-client</artifactId>
       <version>1.10.0-thrift-0.11.0-inlined</version>
     </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>3.7</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/pegasus/src/main/java/com/yahoo/ycsb/db/PegasusClient.java
+++ b/pegasus/src/main/java/com/yahoo/ycsb/db/PegasusClient.java
@@ -233,7 +233,7 @@ public class PegasusClient extends DB {
       }
       return Status.OK;
     } catch (Exception e) {
-      logger.error("Error multi reading value from table[" + table + "] with key: " + key, e);
+      logger.error("Error multi range reading value from table[" + table + "] with key: " + key, e);
       return Status.ERROR;
     }
   }

--- a/pegasus/src/main/java/com/yahoo/ycsb/db/PegasusClient.java
+++ b/pegasus/src/main/java/com/yahoo/ycsb/db/PegasusClient.java
@@ -48,11 +48,11 @@ public class PegasusClient extends DB {
 
   public static final String CONFIG_PROPERTY = "pegasus.config";
 
-  public static final String OPERATION_WRITE_MODE = "write_mode";
+  public static final String WRITE_MODE = "write_mode";
 
-  public static final String OPERATION_READ_MODE = "read_mode";
+  public static final String READ_MODE = "read_mode";
 
-  public static final String FIELD_COUNT_PROPERTY = "fieldcount";
+  public static final String SORT_KEY_COUNT = "sort_key_count";
 
   /**
    * The PegasusClient implementation that will be used to communicate
@@ -102,9 +102,9 @@ public class PegasusClient extends DB {
   }
 
   private void initOperationMode() throws Exception {
-    String writeModeStr = getProperties().getProperty(OPERATION_WRITE_MODE, "single");
-    String readModeStr = getProperties().getProperty(OPERATION_READ_MODE, "single");
-    String sortKeysCountStr = getProperties().getProperty(FIELD_COUNT_PROPERTY, "10");
+    String writeModeStr = getProperties().getProperty(WRITE_MODE, "single");
+    String readModeStr = getProperties().getProperty(READ_MODE, "single");
+    String sortKeysCountStr = getProperties().getProperty(SORT_KEY_COUNT, "10");
 
     int count = Integer.parseInt(sortKeysCountStr);
     startSortKey = String.valueOf(0).getBytes();
@@ -159,11 +159,11 @@ public class PegasusClient extends DB {
     HashMap<String, ByteIterator> result) {
     switch (readMode) {
       case SINGLE:
-        return singleGet(table, key, fields, result);
+        return get(table, key, fields, result);
       case BATCH:
         return batchGet(table, key, fields, result);
       case MULTI:
-        return multiGetAll(table, key, fields, result);
+        return multiGet(table, key, fields, result);
       case RANGE:
         return multiGetRange(table, key, fields, result);
       default:
@@ -172,7 +172,7 @@ public class PegasusClient extends DB {
   }
 
 
-  private Status singleGet(
+  private Status get(
     String table, String key, Set<String> fields,
     Map<String, ByteIterator> result) {
     try {
@@ -210,7 +210,7 @@ public class PegasusClient extends DB {
     }
   }
 
-  private Status multiGetAll(
+  private Status multiGet(
     String table, String key, Set<String> fields,
     Map<String, ByteIterator> result) {
     try {
@@ -258,7 +258,7 @@ public class PegasusClient extends DB {
     String table, String key, HashMap<String, ByteIterator> values) {
     switch (writeMode) {
       case SINGLE:
-        return singleSet(table, key, values);
+        return set(table, key, values);
       case BATCH:
         return batchSet(table, key, values);
       case MULTI:
@@ -273,7 +273,7 @@ public class PegasusClient extends DB {
     String table, String key, HashMap<String, ByteIterator> values) {
     switch (writeMode) {
       case SINGLE:
-        return singleSet(table, key, values);
+        return set(table, key, values);
       case BATCH:
         return batchSet(table, key, values);
       case MULTI:
@@ -283,7 +283,7 @@ public class PegasusClient extends DB {
     }
   }
 
-  private Status singleSet(String table, String key, Map<String, ByteIterator> values) {
+  private Status set(String table, String key, Map<String, ByteIterator> values) {
     try {
       pegasusClient().set(table, key.getBytes(), null, toJson(values));
       return Status.OK;

--- a/pegasus/src/main/java/com/yahoo/ycsb/db/PegasusClient.java
+++ b/pegasus/src/main/java/com/yahoo/ycsb/db/PegasusClient.java
@@ -187,6 +187,7 @@ public class PegasusClient extends DB {
     }
   }
 
+  //note:The hashKeys are designed to be the same, but no impact on performance
   private Status batchGet(
     String table, String key, Set<String> fields,
     Map<String, ByteIterator> result) {
@@ -293,6 +294,7 @@ public class PegasusClient extends DB {
     }
   }
 
+  //note:The hashKeys are designed to be the same, but no impact on performance
   private Status batchSet(String table, String key, HashMap<String, ByteIterator> values) {
     try {
       List<SetItem> setItemList = new ArrayList<>();

--- a/pegasus/src/main/java/com/yahoo/ycsb/db/PegasusClient.java
+++ b/pegasus/src/main/java/com/yahoo/ycsb/db/PegasusClient.java
@@ -101,6 +101,14 @@ public class PegasusClient extends DB {
     }
   }
 
+  /**
+   * There are currently six write-read combination modes by default:
+   * single-single; batch-batch; multi-multi; multi-batch; multi-range; batch-multi
+   * Other combinations are considered invalid, for example:
+   * single-multi: setting single value, but can't get multi value
+   * When combinations are invalid, throw exception.
+   * @throws Exception
+   */
   private void initOperationMode() throws Exception {
     String writeModeStr = getProperties().getProperty(WRITE_MODE, "single");
     String readModeStr = getProperties().getProperty(READ_MODE, "single");

--- a/pegasus/src/main/java/com/yahoo/ycsb/db/PegasusClient.java
+++ b/pegasus/src/main/java/com/yahoo/ycsb/db/PegasusClient.java
@@ -107,9 +107,9 @@ public class PegasusClient extends DB {
    * Other combinations are considered invalid, for example:
    * single-multi: setting single value, but can't get multi value
    * When combinations are invalid, throw exception.
-   * @throws Exception
+   * @throws IllegalArgumentException
    */
-  private void initOperationMode() throws Exception {
+  private void initOperationMode() throws IllegalArgumentException {
     String writeModeStr = getProperties().getProperty(WRITE_MODE, "single");
     String readModeStr = getProperties().getProperty(READ_MODE, "single");
     String sortKeysCountStr = getProperties().getProperty(SORT_KEY_COUNT, "10");
@@ -124,32 +124,27 @@ public class PegasusClient extends DB {
     if (writeModeStr.equals("single") && readModeStr.equals("single")) {
       writeMode = WriteMode.SINGLE;
       readMode = ReadMode.SINGLE;
-      System.out.println("OperationMode:write=single,read=single");
     } else if (writeModeStr.equals("batch") && readModeStr.equals("batch")) {
       writeMode = WriteMode.BATCH;
       readMode = ReadMode.BATCH;
-      System.out.println("OperationMode:write=batch,read=batch");
     } else if (writeModeStr.equals("multi") && readModeStr.equals("multi")) {
       writeMode = WriteMode.MULTI;
       readMode = ReadMode.MULTI;
-      System.out.println("OperationMode:write=multi,read=multi");
     } else if (writeModeStr.equals("multi") && readModeStr.equals("batch")) {
       writeMode = WriteMode.MULTI;
       readMode = ReadMode.BATCH;
-      System.out.println("OperationMode:write=multi,read=batch");
     } else if (writeModeStr.equals("multi") && readModeStr.equals("range")) {
       writeMode = WriteMode.MULTI;
       readMode = ReadMode.RANGE;
-      System.out.println("OperationMode:write=multi,read=range");
     } else if (writeModeStr.equals("batch") && readModeStr.equals("multi")) {
       writeMode = WriteMode.BATCH;
       readMode = ReadMode.MULTI;
-      System.out.println("OperationMode:write=batch,read=multi");
     } else {
       writeMode = WriteMode.INVALID;
       readMode = ReadMode.INVALID;
-      throw new Exception("The Operation mode is not been set right");
+      throw new IllegalArgumentException("The operation mode is not been supported");
     }
+    System.out.println("OperationMode:writeMode=" + writeModeStr + ",readMode=" + readModeStr);
   }
 
   private void initPegasusClient() throws PException {
@@ -195,7 +190,7 @@ public class PegasusClient extends DB {
     }
   }
 
-  //note:The hashKeys are designed to be the same, but no impact on performance
+  //todo:The hashKeys are designed to be the same, maybe impact on performance
   private Status batchGet(
     String table, String key, Set<String> fields,
     Map<String, ByteIterator> result) {
@@ -302,7 +297,7 @@ public class PegasusClient extends DB {
     }
   }
 
-  //note:The hashKeys are designed to be the same, but no impact on performance
+  //todo:The hashKeys are designed to be the same, maybe impact on performance
   private Status batchSet(String table, String key, HashMap<String, ByteIterator> values) {
     try {
       List<SetItem> setItemList = new ArrayList<>();

--- a/workloads/workload_pegasus
+++ b/workloads/workload_pegasus
@@ -15,14 +15,15 @@ requestdistribution=zipfian
 maxscanlength=1000
 scanlengthdistribution=uniform
 insertorder=hashed
-operationcount=100000000
+operationcount=100000
 
 table=usertable
-recordcount=100000000
+result_table=result
+recordcount=100
 core_workload_insertion_retry_limit=10
 core_workload_insertion_retry_interval=3
 
 write_mode=single
 read_mode=single
 fieldcount=10
-hdrhistogram.percentiles=95,99,999,9999
+hdrhistogram.percentiles=95,99,99.9,99.99

--- a/workloads/workload_pegasus
+++ b/workloads/workload_pegasus
@@ -2,7 +2,6 @@ workload=com.yahoo.ycsb.workloads.CoreWorkload
 db=com.yahoo.ycsb.db.PegasusClient
 threadcount=10
 
-fieldcount=1
 fieldlength=500
 readallfields=true
 
@@ -22,3 +21,8 @@ table=usertable
 recordcount=100000000
 core_workload_insertion_retry_limit=10
 core_workload_insertion_retry_interval=3
+
+write_mode=single
+read_mode=single
+fieldcount=10
+hdrhistogram.percentiles=95,99,999,9999

--- a/workloads/workload_pegasus
+++ b/workloads/workload_pegasus
@@ -2,6 +2,7 @@ workload=com.yahoo.ycsb.workloads.CoreWorkload
 db=com.yahoo.ycsb.db.PegasusClient
 threadcount=10
 
+fieldcount=1
 fieldlength=500
 readallfields=true
 
@@ -19,11 +20,11 @@ operationcount=100000
 
 table=usertable
 result_table=result
-recordcount=100
+recordcount=100000000
 core_workload_insertion_retry_limit=10
 core_workload_insertion_retry_interval=3
 
 write_mode=single
 read_mode=single
-fieldcount=10
+sort_key_count=10
 hdrhistogram.percentiles=95,99,99.9,99.99


### PR DESCRIPTION
添加pegasus client更多读写类型的测试接口。
1、通过配置workload实现YCSB不同读写接口调用：
```
write_mode=[single/multi/batch]//数据写入方式
read_mode=[single/multi/batch/range] //数据读出方式，range为multi_get_range
sort_key_count=10 //sortkey数量，同时也是sortkey默认生成方式（如果是10，则sortkey值为0到9）
```
2、支持P999等多指标的测试，需要在workload中添加：
```
hdrhistogram.percentiles=95,99,99.9,99.99
````
3、目前默认存在6种write-read组合模式：
single-single;batch-batch;multi-multi;multi-batch;multi-range;batch-multi
其他组合方式认为是无效的，当组合方式无效时，采用抛出异常的处理策略，请确认默认组合方式是否存在无效组合。